### PR TITLE
Simplify copy button feedback messages in Markdown Editor

### DIFF
--- a/markdown_editor/templates/markdown_editor/markdown_editor.html
+++ b/markdown_editor/templates/markdown_editor/markdown_editor.html
@@ -69,9 +69,9 @@
         const copyMarkdownBtnText = copyMarkdownBtn.textContent;
 
         if (markdownCopySuccess) {
-          copyMarkdownBtn.textContent = 'Copied! 👍';
+          copyMarkdownBtn.textContent = '👍';
         } else {
-          copyMarkdownBtn.textContent = 'Copy failed 😢';
+          copyMarkdownBtn.textContent = '😢';
         }
 
         setTimeout(() => {
@@ -85,13 +85,13 @@
         const copyHtmlBtnText = copyHtmlBtn.textContent;
 
         navigator.clipboard.writeText(previewContent).then(() => {
-          copyHtmlBtn.textContent = 'Copied! 👍';
+          copyHtmlBtn.textContent = '👍';
           setTimeout(() => {
             copyHtmlBtn.textContent = copyHtmlBtnText;
           }, 3000);
         }).catch(err => {
           console.error('Failed to copy: ', err);
-          copyHtmlBtn.textContent = 'Copy failed 😢';
+          copyHtmlBtn.textContent = '😢';
           setTimeout(() => {
             copyHtmlBtn.textContent = copyHtmlBtnText;
           }, 3000);


### PR DESCRIPTION
Streamline the feedback messages for the copy buttons in the Markdown Editor to use only emojis, enhancing clarity and reducing text clutter.