### PR TITLE
Add location parameter to S3 storage configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -367,6 +367,7 @@ STORAGES = {
             "bucket_name": "stuartmnz-public",
             "endpoint_url": env("AWS_ENDPOINT_URL"),
             "custom_domain": "s.stuartm.nz",
+            "location": "static",
         },
     },
 }


### PR DESCRIPTION
Introduce a location parameter in the S3 storage configuration to specify the storage location.