### PR TITLE
Update djpress to version 0.19.2 and boto3/botocore to 1.38.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
   "django-environ>=0.11.2",
   "django~=5.2.0",
-  "djpress==0.19.1b0",
+  "djpress~=0.19",
   "whitenoise>=6.7.0",
   "gunicorn>=23.0.0",
   "rich>=13.8.1",

--- a/uv.lock
+++ b/uv.lock
@@ -35,30 +35,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.38.29"
+version = "1.38.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/d2/e7286b4ffd3138eb13caaa0f611c2e291f7c6b14ae56bf087ce213c54dc4/boto3-1.38.29.tar.gz", hash = "sha256:0777a87e8d28ebae09a086017a53bcaf25ec7c094d8f7e4122b265aa48e273f5", size = 111867, upload-time = "2025-06-03T19:23:00.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a0/24b6c44af60a242318353cefe3494711a71e1a61a62083b5b949a0d4049b/boto3-1.38.30.tar.gz", hash = "sha256:17af769544b5743843bcc732709b43226de19f1ebff2c324a3440bbecbddb893", size = 111801, upload-time = "2025-06-04T19:22:52.709Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/2e/b96b9fbed3007e67bc624c42103b47e7bd10380ed46bbbd25a1755227f7c/boto3-1.38.29-py3-none-any.whl", hash = "sha256:90a9b1a08122b840216b0e33b7b0dbe4ef50f12d00a573bf7b030cddeda9c507", size = 139939, upload-time = "2025-06-03T19:22:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f3/6f98c044b81b93587db6b920723541ef5e90aa93804ce15ea4ff4776be81/boto3-1.38.30-py3-none-any.whl", hash = "sha256:949df0a0edd360f4ad60f1492622eecf98a359a2f72b1e236193d9b320c5dc8c", size = 139936, upload-time = "2025-06-04T19:22:49.171Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.38.29"
+version = "1.38.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/9a/8c3ec27698910c1b94152f9e7a345d4c6c2f49dfc41d8336f82e32c32ed1/botocore-1.38.29.tar.gz", hash = "sha256:98c42b1bbb52f4086282e7db8aa724c9cb0f7278b7827d6736d872511c856e4f", size = 13929364, upload-time = "2025-06-03T19:22:48.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e6/2eaaf27202477306a637f521bff7230c9a9cdfb89d938db32c256fd18f54/botocore-1.38.30.tar.gz", hash = "sha256:7836c5041c5f249431dbd5471c61db17d4053f72a1d6e3b2197c07ca0839588b", size = 13942340, upload-time = "2025-06-04T19:22:39.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/7a/03482cd3c00008d9be646c8e1520611d6202ce447db725ac40b07f9b088a/botocore-1.38.29-py3-none-any.whl", hash = "sha256:4d623f54326eb66d1a633f0c1780992c80f3db317a91c9afe31d5c700290621e", size = 13588258, upload-time = "2025-06-03T19:22:45.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cd/04fc0032a98196c34f46d7ea58c9f3e32eb3ad430a1e37e433a3049fd6ea/botocore-1.38.30-py3-none-any.whl", hash = "sha256:530e40a6e91c8a096cab17fcc590d0c7227c8347f71a867576163a44d027a714", size = 13603795, upload-time = "2025-06-04T19:22:34.984Z" },
 ]
 
 [[package]]
@@ -189,15 +189,15 @@ s3 = [
 
 [[package]]
 name = "djpress"
-version = "0.19.1b0"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "markdown" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/1d/ca7e9cb8f43168d0c2672b76fe18be426acff5e4b4e30c7b79e441964ac3/djpress-0.19.1b0.tar.gz", hash = "sha256:1b601badaa17949cc6043904bf749f80f52430fb935d23da88329573e23e82e8", size = 158318, upload-time = "2025-06-04T14:11:07.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/00/1de5780ab9c222ef5a385c1b09c627b7157a040365adbc4ea77024e5caeb/djpress-0.19.2.tar.gz", hash = "sha256:9cb0c49d05a84f6b02e2f0b620355c7109981bf80e2b651c39971750b5b77b51", size = 158694, upload-time = "2025-06-05T04:09:19.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/58/2c47f88ae45fbffe7d236f2a9c4c6724b97fa7545c825be1fce736f1cd75/djpress-0.19.1b0-py3-none-any.whl", hash = "sha256:13416cfa8e16d9a1d37df16814c590766e91bbc7683ecf3bb55dbc42617d87d1", size = 67155, upload-time = "2025-06-04T14:11:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b9/9f048763dd9e2e7225898b4af69c8dcf7d912734dc679d56432d05779d66/djpress-0.19.2-py3-none-any.whl", hash = "sha256:c3eb411d5e1618a8cc66423b79337ad29b789648dd2f54fa41bc9e86ca206942", size = 67132, upload-time = "2025-06-05T04:09:17.415Z" },
 ]
 
 [[package]]
@@ -782,7 +782,7 @@ requires-dist = [
     { name = "django-debug-toolbar", specifier = ">=4.4.6" },
     { name = "django-environ", specifier = ">=0.11.2" },
     { name = "django-storages", extras = ["s3"], specifier = ">=1.14.6" },
-    { name = "djpress", specifier = "==0.19.1b0" },
+    { name = "djpress", specifier = "~=0.19" },
     { name = "djpress-publish-bluesky", specifier = ">=1.0.0" },
     { name = "djpress-publish-mastodon", specifier = ">=1.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },


### PR DESCRIPTION
Upgrade the djpress package to version 0.19.2 and update boto3 and botocore to version 1.38.30 for improved functionality and compatibility.